### PR TITLE
Adding in missing remote_path for pulling file with  specified

### DIFF
--- a/orchestrator/setup.py
+++ b/orchestrator/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='androidtestorchestrator',
-    version='2.0.0',
+    version='2.0.1',
     package_dir={'': 'src'},
     packages=setuptools.find_packages('src'),
     include_package_data=True,

--- a/orchestrator/src/androidtestorchestrator/devicestorage.py
+++ b/orchestrator/src/androidtestorchestrator/devicestorage.py
@@ -59,7 +59,7 @@ class DeviceStorage(RemoteDeviceBased):
             log.warning("File %s already exists when pulling. Potential to overwrite files.", local_path)
         if run_as:
             with open(local_path, 'w') as out:
-                self.device.execute_remote_cmd('shell', 'run-as', run_as, 'cat', stdout=out)
+                self.device.execute_remote_cmd('shell', 'run-as', run_as, 'cat', remote_path, stdout=out)
         else:
             self.device.execute_remote_cmd('pull', remote_path, local_path)
 


### PR DESCRIPTION
Fixing DeviceStorage.pull to set the `remote_path` when using the `run_as` option.